### PR TITLE
test: add virtual dtor to abstract classes

### DIFF
--- a/test/i965_jpeg_test_data.h
+++ b/test/i965_jpeg_test_data.h
@@ -276,6 +276,8 @@ namespace Decode {
         typedef std::shared_ptr<TestPattern> Shared;
         typedef std::shared_ptr<const TestPattern> SharedConst;
 
+        virtual ~TestPattern() { }
+
         virtual const ByteData& decoded() const = 0;
         virtual PictureData::SharedConst encoded(unsigned) const = 0;
 
@@ -430,6 +432,8 @@ namespace Encode {
     public:
         typedef std::shared_ptr<TestInputCreator> Shared;
         typedef std::shared_ptr<const TestInputCreator> SharedConst;
+
+        virtual ~TestInputCreator() { }
 
         TestInput::Shared create(const unsigned) const;
 


### PR DESCRIPTION
Abstract classes should have virtual destructors.
Missing virtual dtor's can be detected with
-Wnon-virtual-dtor compiler flag, too.

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>