### PR TITLE
Clang warnings

### DIFF
--- a/src/gen10_hevc_encoder.c
+++ b/src/gen10_hevc_encoder.c
@@ -1000,7 +1000,6 @@ gen10_hevc_allocate_enc_resources(VADriverContextP ctx,
     i965_free_gpe_resource(&vme_context->res_jbq_data_lcu32_surface);
     dw_width = ALIGN(hevc_state->frame_width, 64);
     dw_height = (ALIGN(hevc_state->frame_height, 64) >> 5) * 58;
-    dw_width = dw_width;
     allocate_flag = i965_gpe_allocate_2d_resource(i965->intel.bufmgr,
                                                   &vme_context->res_jbq_data_lcu32_surface,
                                                   dw_width, dw_height, dw_width,
@@ -1115,7 +1114,6 @@ gen10_hevc_allocate_enc_resources(VADriverContextP ctx,
     dw_width = ALIGN(dw_width, 64);
     dw_height = ALIGN(hevc_state->frame_height, 64) >> 4;
     dw_height = ALIGN(dw_height, 64);
-    dw_width = dw_width;
     allocate_flag = i965_gpe_allocate_2d_resource(i965->intel.bufmgr,
                                                   &vme_context->res_brc_me_dist_surface,
                                                   dw_width, dw_height, dw_width,
@@ -1146,7 +1144,6 @@ gen10_hevc_allocate_enc_resources(VADriverContextP ctx,
     i965_free_gpe_resource(&vme_context->res_brc_intra_dist_surface);
     dw_width = ALIGN(hevc_state->frame_width_4x / 2, 64);
     dw_height = ALIGN(hevc_state->frame_height_4x / 4, 8) * 2;
-    dw_width = dw_width;
     allocate_flag = i965_gpe_allocate_2d_resource(i965->intel.bufmgr,
                                                   &vme_context->res_brc_intra_dist_surface,
                                                   dw_width, dw_height, dw_width,
@@ -1188,7 +1185,6 @@ gen10_hevc_allocate_enc_resources(VADriverContextP ctx,
     i965_free_gpe_resource(&vme_context->res_brc_const_data_surface);
     dw_width = ALIGN(GEN10_HEVC_BRC_CONST_SURFACE_WIDTH, 64);
     dw_height = ALIGN(GEN10_HEVC_BRC_CONST_SURFACE_HEIGHT, 32);
-    dw_width = dw_width;
     allocate_flag = i965_gpe_allocate_2d_resource(i965->intel.bufmgr,
                                                   &vme_context->res_brc_const_data_surface,
                                                   dw_width, dw_height, dw_width,
@@ -1213,7 +1209,6 @@ gen10_hevc_allocate_enc_resources(VADriverContextP ctx,
 
     dw_width = ALIGN(dw_width, 64);
     dw_height = ALIGN(dw_height, 8);
-    dw_width = dw_width;
     allocate_flag = i965_gpe_allocate_2d_resource(i965->intel.bufmgr,
                                                   &vme_context->res_brc_mb_qp_surface,
                                                   dw_width, dw_height, dw_width,

--- a/src/gen10_hevc_encoder.c
+++ b/src/gen10_hevc_encoder.c
@@ -200,17 +200,17 @@ gen10_hevc_init_vfe_scoreboard(struct i965_gpe_context *gpe_context,
         gpe_context->vfe_desc7.dword = 0;
     } else {
         gpe_context->vfe_desc5.scoreboard0.mask = 0x7F;
-        gpe_context->vfe_desc6.scoreboard1.delta_x0 = 0xF;
-        gpe_context->vfe_desc6.scoreboard1.delta_y0 = 0x0;
+        gpe_context->vfe_desc6.scoreboard1.delta_x0 = -1;
+        gpe_context->vfe_desc6.scoreboard1.delta_y0 = 0;
 
-        gpe_context->vfe_desc6.scoreboard1.delta_x1 = 0xF;
-        gpe_context->vfe_desc6.scoreboard1.delta_y1 = 0xF;
+        gpe_context->vfe_desc6.scoreboard1.delta_x1 = -1;
+        gpe_context->vfe_desc6.scoreboard1.delta_y1 = -1;
 
-        gpe_context->vfe_desc6.scoreboard1.delta_x2 = 0x0;
-        gpe_context->vfe_desc6.scoreboard1.delta_y2 = 0xF;
+        gpe_context->vfe_desc6.scoreboard1.delta_x2 = 0;
+        gpe_context->vfe_desc6.scoreboard1.delta_y2 = -1;
 
         gpe_context->vfe_desc6.scoreboard1.delta_x3 = 1;
-        gpe_context->vfe_desc6.scoreboard1.delta_y3 = 0xF;
+        gpe_context->vfe_desc6.scoreboard1.delta_y3 = -1;
 
         gpe_context->vfe_desc7.scoreboard2.delta_x4 = 0;
         gpe_context->vfe_desc7.scoreboard2.delta_y4 = 0;
@@ -4544,17 +4544,17 @@ gen10_hevc_mbenc_init_walker_param(struct gen10_hevc_enc_state *hevc_state,
         hw_scoreboard->scoreboard0.enable = hevc_state->use_hw_scoreboard;
         hw_scoreboard->scoreboard0.type = hevc_state->use_hw_non_stalling_scoreboard;
 
-        hw_scoreboard->dw1.scoreboard1.delta_x0 = 0xF;
-        hw_scoreboard->dw1.scoreboard1.delta_y0 = 0x0;
+        hw_scoreboard->dw1.scoreboard1.delta_x0 = -1;
+        hw_scoreboard->dw1.scoreboard1.delta_y0 = 0;
 
-        hw_scoreboard->dw1.scoreboard1.delta_x1 = 0x0;
-        hw_scoreboard->dw1.scoreboard1.delta_y1 = 0xF;
+        hw_scoreboard->dw1.scoreboard1.delta_x1 = 0;
+        hw_scoreboard->dw1.scoreboard1.delta_y1 = -1;
 
         hw_scoreboard->dw1.scoreboard1.delta_x2 = 1;
-        hw_scoreboard->dw1.scoreboard1.delta_y2 = 0xF;
+        hw_scoreboard->dw1.scoreboard1.delta_y2 = -1;
 
-        hw_scoreboard->dw1.scoreboard1.delta_x3 = 0xF;
-        hw_scoreboard->dw1.scoreboard1.delta_y3 = 0xF;
+        hw_scoreboard->dw1.scoreboard1.delta_x3 = -1;
+        hw_scoreboard->dw1.scoreboard1.delta_y3 = -1;
 
         hw_scoreboard->dw2.scoreboard2.delta_x4 = 0;
         hw_scoreboard->dw2.scoreboard2.delta_y4 = 0;

--- a/src/gen10_vdenc_vp9.c
+++ b/src/gen10_vdenc_vp9.c
@@ -724,49 +724,49 @@ gen10_vdenc_vp9_gpe_context_vfe_scoreboard_init(struct i965_gpe_context *gpe_con
         gpe_context->vfe_desc5.scoreboard0.mask = 0x0F;
         gpe_context->vfe_desc5.scoreboard0.type = 1;
 
-        gpe_context->vfe_desc6.scoreboard1.delta_x0 = 0x0;
-        gpe_context->vfe_desc6.scoreboard1.delta_y0 = 0xF;
+        gpe_context->vfe_desc6.scoreboard1.delta_x0 = 0;
+        gpe_context->vfe_desc6.scoreboard1.delta_y0 = -1;
 
-        gpe_context->vfe_desc6.scoreboard1.delta_x1 = 0x0;
-        gpe_context->vfe_desc6.scoreboard1.delta_y1 = 0xE;
+        gpe_context->vfe_desc6.scoreboard1.delta_x1 = 0;
+        gpe_context->vfe_desc6.scoreboard1.delta_y1 = -2;
 
-        gpe_context->vfe_desc6.scoreboard1.delta_x2 = 0xF;
-        gpe_context->vfe_desc6.scoreboard1.delta_y2 = 0x3;
+        gpe_context->vfe_desc6.scoreboard1.delta_x2 = -1;
+        gpe_context->vfe_desc6.scoreboard1.delta_y2 = 3;
 
-        gpe_context->vfe_desc6.scoreboard1.delta_x3 = 0xF;
-        gpe_context->vfe_desc6.scoreboard1.delta_y3 = 0x1;
+        gpe_context->vfe_desc6.scoreboard1.delta_x3 = -1;
+        gpe_context->vfe_desc6.scoreboard1.delta_y3 = 1;
     } else {
         // Scoreboard 0
-        gpe_context->vfe_desc6.scoreboard1.delta_x0 = 0xF;
-        gpe_context->vfe_desc6.scoreboard1.delta_y0 = 0x0;
+        gpe_context->vfe_desc6.scoreboard1.delta_x0 = -1;
+        gpe_context->vfe_desc6.scoreboard1.delta_y0 = 0;
 
         // Scoreboard 1
-        gpe_context->vfe_desc6.scoreboard1.delta_x1 = 0x0;
-        gpe_context->vfe_desc6.scoreboard1.delta_y1 = 0xF;
+        gpe_context->vfe_desc6.scoreboard1.delta_x1 = 0;
+        gpe_context->vfe_desc6.scoreboard1.delta_y1 = -1;
 
         // Scoreboard 2
-        gpe_context->vfe_desc6.scoreboard1.delta_x2 = 0x1;
-        gpe_context->vfe_desc6.scoreboard1.delta_y2 = 0xF;
+        gpe_context->vfe_desc6.scoreboard1.delta_x2 = 1;
+        gpe_context->vfe_desc6.scoreboard1.delta_y2 = -1;
 
         // Scoreboard 3
-        gpe_context->vfe_desc6.scoreboard1.delta_x3 = 0xF;
-        gpe_context->vfe_desc6.scoreboard1.delta_y3 = 0xF;
+        gpe_context->vfe_desc6.scoreboard1.delta_x3 = -1;
+        gpe_context->vfe_desc6.scoreboard1.delta_y3 = -1;
 
         // Scoreboard 4
-        gpe_context->vfe_desc7.scoreboard2.delta_x4 = 0xF;
-        gpe_context->vfe_desc7.scoreboard2.delta_y4 = 0x1;
+        gpe_context->vfe_desc7.scoreboard2.delta_x4 = -1;
+        gpe_context->vfe_desc7.scoreboard2.delta_y4 = 1;
 
         // Scoreboard 5
-        gpe_context->vfe_desc7.scoreboard2.delta_x5 = 0x0;
-        gpe_context->vfe_desc7.scoreboard2.delta_y5 = 0xE;
+        gpe_context->vfe_desc7.scoreboard2.delta_x5 = 0;
+        gpe_context->vfe_desc7.scoreboard2.delta_y5 = -2;
 
         // Scoreboard 6
-        gpe_context->vfe_desc7.scoreboard2.delta_x6 = 0x1;
-        gpe_context->vfe_desc7.scoreboard2.delta_y6 = 0xE;
+        gpe_context->vfe_desc7.scoreboard2.delta_x6 = 1;
+        gpe_context->vfe_desc7.scoreboard2.delta_y6 = -2;
 
         // Scoreboard 7
-        gpe_context->vfe_desc7.scoreboard2.delta_x6 = 0xF;
-        gpe_context->vfe_desc7.scoreboard2.delta_y6 = 0xE;
+        gpe_context->vfe_desc7.scoreboard2.delta_x6 = -1;
+        gpe_context->vfe_desc7.scoreboard2.delta_y6 = -2;
     }
 }
 

--- a/src/gen9_hevc_encoder.c
+++ b/src/gen9_hevc_encoder.c
@@ -1371,29 +1371,29 @@ gen9_hevc_vme_init_scoreboard(struct i965_gpe_context *gpe_context,
     gpe_context->vfe_desc5.scoreboard0.type = type;
     gpe_context->vfe_desc5.scoreboard0.enable = enable;
 
-    gpe_context->vfe_desc6.scoreboard1.delta_x0 = 0xF;
-    gpe_context->vfe_desc6.scoreboard1.delta_y0 = 0x0;
+    gpe_context->vfe_desc6.scoreboard1.delta_x0 = -1;
+    gpe_context->vfe_desc6.scoreboard1.delta_y0 = 0;
 
-    gpe_context->vfe_desc6.scoreboard1.delta_x1 = 0x0;
-    gpe_context->vfe_desc6.scoreboard1.delta_y1 = 0xF;
+    gpe_context->vfe_desc6.scoreboard1.delta_x1 = 0;
+    gpe_context->vfe_desc6.scoreboard1.delta_y1 = -1;
 
-    gpe_context->vfe_desc6.scoreboard1.delta_x2 = 0x1;
-    gpe_context->vfe_desc6.scoreboard1.delta_y2 = 0xF;
+    gpe_context->vfe_desc6.scoreboard1.delta_x2 = 1;
+    gpe_context->vfe_desc6.scoreboard1.delta_y2 = -1;
 
-    gpe_context->vfe_desc6.scoreboard1.delta_x3 = 0xF;
-    gpe_context->vfe_desc6.scoreboard1.delta_y3 = 0xF;
+    gpe_context->vfe_desc6.scoreboard1.delta_x3 = -1;
+    gpe_context->vfe_desc6.scoreboard1.delta_y3 = -1;
 
-    gpe_context->vfe_desc7.scoreboard2.delta_x4 = 0xF;
-    gpe_context->vfe_desc7.scoreboard2.delta_y4 = 0x1;
+    gpe_context->vfe_desc7.scoreboard2.delta_x4 = -1;
+    gpe_context->vfe_desc7.scoreboard2.delta_y4 = 1;
 
-    gpe_context->vfe_desc7.scoreboard2.delta_x5 = 0x0;
-    gpe_context->vfe_desc7.scoreboard2.delta_y5 = 0xE;
+    gpe_context->vfe_desc7.scoreboard2.delta_x5 = 0;
+    gpe_context->vfe_desc7.scoreboard2.delta_y5 = -2;
 
-    gpe_context->vfe_desc7.scoreboard2.delta_x6 = 0x1;
-    gpe_context->vfe_desc7.scoreboard2.delta_y6 = 0xE;
+    gpe_context->vfe_desc7.scoreboard2.delta_x6 = 1;
+    gpe_context->vfe_desc7.scoreboard2.delta_y6 = -2;
 
-    gpe_context->vfe_desc7.scoreboard2.delta_x7 = 0xF;
-    gpe_context->vfe_desc7.scoreboard2.delta_y7 = 0xE;
+    gpe_context->vfe_desc7.scoreboard2.delta_x7 = -1;
+    gpe_context->vfe_desc7.scoreboard2.delta_y7 = -2;
 }
 
 static void

--- a/src/gen9_vp9_encoder.c
+++ b/src/gen9_vp9_encoder.c
@@ -3526,49 +3526,49 @@ gen9_init_vfe_scoreboard_vp9(struct i965_gpe_context *gpe_context,
         gpe_context->vfe_desc5.scoreboard0.mask = 0x0F;
         gpe_context->vfe_desc5.scoreboard0.type = 1;
 
-        gpe_context->vfe_desc6.scoreboard1.delta_x0 = 0x0;
-        gpe_context->vfe_desc6.scoreboard1.delta_y0 = 0xF;
+        gpe_context->vfe_desc6.scoreboard1.delta_x0 = 0;
+        gpe_context->vfe_desc6.scoreboard1.delta_y0 = -1;
 
-        gpe_context->vfe_desc6.scoreboard1.delta_x1 = 0x0;
-        gpe_context->vfe_desc6.scoreboard1.delta_y1 = 0xE;
+        gpe_context->vfe_desc6.scoreboard1.delta_x1 = 0;
+        gpe_context->vfe_desc6.scoreboard1.delta_y1 = -2;
 
-        gpe_context->vfe_desc6.scoreboard1.delta_x2 = 0xF;
-        gpe_context->vfe_desc6.scoreboard1.delta_y2 = 0x3;
+        gpe_context->vfe_desc6.scoreboard1.delta_x2 = -1;
+        gpe_context->vfe_desc6.scoreboard1.delta_y2 = 3;
 
-        gpe_context->vfe_desc6.scoreboard1.delta_x3 = 0xF;
-        gpe_context->vfe_desc6.scoreboard1.delta_y3 = 0x1;
+        gpe_context->vfe_desc6.scoreboard1.delta_x3 = -1;
+        gpe_context->vfe_desc6.scoreboard1.delta_y3 = 1;
     } else {
         // Scoreboard 0
-        gpe_context->vfe_desc6.scoreboard1.delta_x0 = 0xF;
-        gpe_context->vfe_desc6.scoreboard1.delta_y0 = 0x0;
+        gpe_context->vfe_desc6.scoreboard1.delta_x0 = -1;
+        gpe_context->vfe_desc6.scoreboard1.delta_y0 = 0;
 
         // Scoreboard 1
-        gpe_context->vfe_desc6.scoreboard1.delta_x1 = 0x0;
-        gpe_context->vfe_desc6.scoreboard1.delta_y1 = 0xF;
+        gpe_context->vfe_desc6.scoreboard1.delta_x1 = 0;
+        gpe_context->vfe_desc6.scoreboard1.delta_y1 = -1;
 
         // Scoreboard 2
-        gpe_context->vfe_desc6.scoreboard1.delta_x2 = 0x1;
-        gpe_context->vfe_desc6.scoreboard1.delta_y2 = 0xF;
+        gpe_context->vfe_desc6.scoreboard1.delta_x2 = 1;
+        gpe_context->vfe_desc6.scoreboard1.delta_y2 = -1;
 
         // Scoreboard 3
-        gpe_context->vfe_desc6.scoreboard1.delta_x3 = 0xF;
-        gpe_context->vfe_desc6.scoreboard1.delta_y3 = 0xF;
+        gpe_context->vfe_desc6.scoreboard1.delta_x3 = -1;
+        gpe_context->vfe_desc6.scoreboard1.delta_y3 = -1;
 
         // Scoreboard 4
-        gpe_context->vfe_desc7.scoreboard2.delta_x4 = 0xF;
-        gpe_context->vfe_desc7.scoreboard2.delta_y4 = 0x1;
+        gpe_context->vfe_desc7.scoreboard2.delta_x4 = -1;
+        gpe_context->vfe_desc7.scoreboard2.delta_y4 = 1;
 
         // Scoreboard 5
-        gpe_context->vfe_desc7.scoreboard2.delta_x5 = 0x0;
-        gpe_context->vfe_desc7.scoreboard2.delta_y5 = 0xE;
+        gpe_context->vfe_desc7.scoreboard2.delta_x5 = 0;
+        gpe_context->vfe_desc7.scoreboard2.delta_y5 = -2;
 
         // Scoreboard 6
-        gpe_context->vfe_desc7.scoreboard2.delta_x6 = 0x1;
-        gpe_context->vfe_desc7.scoreboard2.delta_y6 = 0xE;
+        gpe_context->vfe_desc7.scoreboard2.delta_x6 = 1;
+        gpe_context->vfe_desc7.scoreboard2.delta_y6 = -2;
 
         // Scoreboard 7
-        gpe_context->vfe_desc7.scoreboard2.delta_x6 = 0xF;
-        gpe_context->vfe_desc7.scoreboard2.delta_y6 = 0xE;
+        gpe_context->vfe_desc7.scoreboard2.delta_x6 = -1;
+        gpe_context->vfe_desc7.scoreboard2.delta_y6 = -2;
     }
 }
 

--- a/src/i965_avc_encoder.c
+++ b/src/i965_avc_encoder.c
@@ -1521,49 +1521,49 @@ gen9_init_vfe_scoreboard_avc(struct i965_gpe_context *gpe_context,
         gpe_context->vfe_desc5.scoreboard0.mask = 0x0F;
         gpe_context->vfe_desc5.scoreboard0.type = 1;
 
-        gpe_context->vfe_desc6.scoreboard1.delta_x0 = 0x0;
-        gpe_context->vfe_desc6.scoreboard1.delta_y0 = 0xF;
+        gpe_context->vfe_desc6.scoreboard1.delta_x0 = 0;
+        gpe_context->vfe_desc6.scoreboard1.delta_y0 = -1;
 
-        gpe_context->vfe_desc6.scoreboard1.delta_x1 = 0x0;
-        gpe_context->vfe_desc6.scoreboard1.delta_y1 = 0xE;
+        gpe_context->vfe_desc6.scoreboard1.delta_x1 = 0;
+        gpe_context->vfe_desc6.scoreboard1.delta_y1 = -2;
 
-        gpe_context->vfe_desc6.scoreboard1.delta_x2 = 0xF;
-        gpe_context->vfe_desc6.scoreboard1.delta_y2 = 0x3;
+        gpe_context->vfe_desc6.scoreboard1.delta_x2 = -1;
+        gpe_context->vfe_desc6.scoreboard1.delta_y2 = 3;
 
-        gpe_context->vfe_desc6.scoreboard1.delta_x3 = 0xF;
-        gpe_context->vfe_desc6.scoreboard1.delta_y3 = 0x1;
+        gpe_context->vfe_desc6.scoreboard1.delta_x3 = -1;
+        gpe_context->vfe_desc6.scoreboard1.delta_y3 = 1;
     } else {
         // Scoreboard 0
-        gpe_context->vfe_desc6.scoreboard1.delta_x0 = 0xF;
-        gpe_context->vfe_desc6.scoreboard1.delta_y0 = 0x0;
+        gpe_context->vfe_desc6.scoreboard1.delta_x0 = -1;
+        gpe_context->vfe_desc6.scoreboard1.delta_y0 = 0;
 
         // Scoreboard 1
-        gpe_context->vfe_desc6.scoreboard1.delta_x1 = 0x0;
-        gpe_context->vfe_desc6.scoreboard1.delta_y1 = 0xF;
+        gpe_context->vfe_desc6.scoreboard1.delta_x1 = 0;
+        gpe_context->vfe_desc6.scoreboard1.delta_y1 = -1;
 
         // Scoreboard 2
-        gpe_context->vfe_desc6.scoreboard1.delta_x2 = 0x1;
-        gpe_context->vfe_desc6.scoreboard1.delta_y2 = 0xF;
+        gpe_context->vfe_desc6.scoreboard1.delta_x2 = 1;
+        gpe_context->vfe_desc6.scoreboard1.delta_y2 = -1;
 
         // Scoreboard 3
-        gpe_context->vfe_desc6.scoreboard1.delta_x3 = 0xF;
-        gpe_context->vfe_desc6.scoreboard1.delta_y3 = 0xF;
+        gpe_context->vfe_desc6.scoreboard1.delta_x3 = -1;
+        gpe_context->vfe_desc6.scoreboard1.delta_y3 = -1;
 
         // Scoreboard 4
-        gpe_context->vfe_desc7.scoreboard2.delta_x4 = 0xF;
-        gpe_context->vfe_desc7.scoreboard2.delta_y4 = 0x1;
+        gpe_context->vfe_desc7.scoreboard2.delta_x4 = -1;
+        gpe_context->vfe_desc7.scoreboard2.delta_y4 = 1;
 
         // Scoreboard 5
-        gpe_context->vfe_desc7.scoreboard2.delta_x5 = 0x0;
-        gpe_context->vfe_desc7.scoreboard2.delta_y5 = 0xE;
+        gpe_context->vfe_desc7.scoreboard2.delta_x5 = 0;
+        gpe_context->vfe_desc7.scoreboard2.delta_y5 = -2;
 
         // Scoreboard 6
-        gpe_context->vfe_desc7.scoreboard2.delta_x6 = 0x1;
-        gpe_context->vfe_desc7.scoreboard2.delta_y6 = 0xE;
+        gpe_context->vfe_desc7.scoreboard2.delta_x6 = 1;
+        gpe_context->vfe_desc7.scoreboard2.delta_y6 = -2;
 
         // Scoreboard 7
-        gpe_context->vfe_desc7.scoreboard2.delta_x6 = 0xF;
-        gpe_context->vfe_desc7.scoreboard2.delta_y6 = 0xE;
+        gpe_context->vfe_desc7.scoreboard2.delta_x6 = -1;
+        gpe_context->vfe_desc7.scoreboard2.delta_y6 = -2;
     }
 }
 /*

--- a/src/i965_encoder_vp8.c
+++ b/src/i965_encoder_vp8.c
@@ -1448,34 +1448,34 @@ i965_encoder_vp8_gpe_context_vfe_scoreboard_init(struct i965_gpe_context *gpe_co
     gpe_context->vfe_desc5.scoreboard0.enable = scoreboard_params->enable;
 
     // Scoreboard 0
-    gpe_context->vfe_desc6.scoreboard1.delta_x0 = 0xF;
-    gpe_context->vfe_desc6.scoreboard1.delta_y0 = 0x0;
+    gpe_context->vfe_desc6.scoreboard1.delta_x0 = -1;
+    gpe_context->vfe_desc6.scoreboard1.delta_y0 = 0;
 
     // Scoreboard 1
-    gpe_context->vfe_desc6.scoreboard1.delta_x1 = 0x0;
-    gpe_context->vfe_desc6.scoreboard1.delta_y1 = 0xF;
+    gpe_context->vfe_desc6.scoreboard1.delta_x1 = 0;
+    gpe_context->vfe_desc6.scoreboard1.delta_y1 = -1;
 
     // Scoreboard 2
-    gpe_context->vfe_desc6.scoreboard1.delta_x2 = 0x1;
-    gpe_context->vfe_desc6.scoreboard1.delta_y2 = 0xF;
+    gpe_context->vfe_desc6.scoreboard1.delta_x2 = 1;
+    gpe_context->vfe_desc6.scoreboard1.delta_y2 = -1;
 
     // Scoreboard 3
-    gpe_context->vfe_desc6.scoreboard1.delta_x3 = 0xF;
-    gpe_context->vfe_desc6.scoreboard1.delta_y3 = 0xF;
+    gpe_context->vfe_desc6.scoreboard1.delta_x3 = -1;
+    gpe_context->vfe_desc6.scoreboard1.delta_y3 = -1;
 
     // Scoreboard 4
-    gpe_context->vfe_desc7.scoreboard2.delta_x4 = 0xF;
-    gpe_context->vfe_desc7.scoreboard2.delta_y4 = 0x1;
+    gpe_context->vfe_desc7.scoreboard2.delta_x4 = -1;
+    gpe_context->vfe_desc7.scoreboard2.delta_y4 = 1;
 
     // Scoreboard 5
-    gpe_context->vfe_desc7.scoreboard2.delta_x5 = 0x0;
-    gpe_context->vfe_desc7.scoreboard2.delta_y5 = 0xE;
+    gpe_context->vfe_desc7.scoreboard2.delta_x5 = 0;
+    gpe_context->vfe_desc7.scoreboard2.delta_y5 = -2;
     // Scoreboard 6
-    gpe_context->vfe_desc7.scoreboard2.delta_x6 = 0x1;
-    gpe_context->vfe_desc7.scoreboard2.delta_y6 = 0xE;
+    gpe_context->vfe_desc7.scoreboard2.delta_x6 = 1;
+    gpe_context->vfe_desc7.scoreboard2.delta_y6 = -2;
     // Scoreboard 7
-    gpe_context->vfe_desc7.scoreboard2.delta_x6 = 0xF;
-    gpe_context->vfe_desc7.scoreboard2.delta_y6 = 0xE;
+    gpe_context->vfe_desc7.scoreboard2.delta_x6 = -1;
+    gpe_context->vfe_desc7.scoreboard2.delta_y6 = -2;
 }
 
 static void

--- a/src/i965_post_processing.c
+++ b/src/i965_post_processing.c
@@ -63,6 +63,8 @@ vpp_surface_convert(VADriverContextP ctx,
 
 #define VA_STATUS_SUCCESS_1                     0xFFFFFFFE
 
+#define BIT_CAST(x) (((union{unsigned int a;int b:8;})x).b)
+
 static const uint32_t pp_null_gen5[][4] = {
 #include "shaders/post_processing/gen5_6/null.g4b.gen5"
 };
@@ -2806,7 +2808,7 @@ pp_nv12_avs_initialize(VADriverContextP ctx, struct i965_post_processing_context
     }
 
     /* Adaptive filter for all channels (DW4.15) */
-    sampler_8x8_state->coefficients[0].dw4.table_1x_filter_c1 = 1U << 7;
+    sampler_8x8_state->coefficients[0].dw4.table_1x_filter_c1 = BIT_CAST((1U << 7));
 
     sampler_8x8_state->dw136.default_sharpness_level =
         -avs_is_needed(pp_context->filter_flags);
@@ -3152,7 +3154,7 @@ gen7_pp_plx_avs_initialize(VADriverContextP ctx, struct i965_post_processing_con
         sampler_8x8_state->dw137.hsw.bypass_y_adaptive_filtering = 1;
         sampler_8x8_state->dw137.hsw.bypass_x_adaptive_filtering = 1;
     } else {
-        sampler_8x8_state->coefficients[0].dw4.table_1x_filter_c1 = 1U << 7;
+        sampler_8x8_state->coefficients[0].dw4.table_1x_filter_c1 = BIT_CAST((1U << 7));
         sampler_8x8_state->dw137.ilk.bypass_y_adaptive_filtering = 1;
         sampler_8x8_state->dw137.ilk.bypass_x_adaptive_filtering = 1;
     }


### PR DESCRIPTION
When compiling with clang, which has more check ups enabled than gcc, some warnings are triggered. Like this

```
warning: implicit truncation from 'int' to bit-field changes value from 15 to -1 [-Wbitfield-constant-conversion]
```

These patches fixes most of them.