### PR TITLE
build: fix meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -69,7 +69,7 @@ if get_option('with_x11') != 'no'
     version : libva_version,
     required : get_option('with_x11') == 'yes')
 
-  HAVE_X11 = libva_x11_dep.found()
+  WITH_X11 = libva_x11_dep.found()
 endif
 
 WITH_WAYLAND = false


### PR DESCRIPTION
When X11 is found, the variable assigned is HAVE_X11 but the used
one is WITH_X11, failing to define it in the config header.

Sorry! :(