### PR TITLE
[DRI3] Enable DRI3 and Present Extension support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,11 @@ AC_ARG_ENABLE(x11,
                     [build with VA/X11 API support @<:@default=yes@:>@])],
     [], [enable_x11="yes"])
 
+AC_ARG_ENABLE(dri3,
+    [AC_HELP_STRING([--enable-dri3],
+                    [build with VA/X11-DRI3 API support @<:@default=no@:>@])],
+    [], [enable_dri3="no"])
+
 AC_ARG_ENABLE([wayland],
     [AC_HELP_STRING([--enable-wayland],
                     [build with VA/Wayland API support @<:@default=yes@:>@])],
@@ -135,6 +140,28 @@ if test "$USE_X11" = "yes"; then
 fi
 AM_CONDITIONAL(USE_X11, test "$USE_X11" = "yes")
 
+dnl Check for DRI3
+USE_DRI3="$enable_dri3"
+
+if test "$USE_X11:$enable_dri3" = "no:yes"; then
+    AC_MSG_ERROR([VA/X11-DRI3 explicitly enabled, but VA/X11 isn't built])
+fi
+
+if test "$enable_dri3" != "no"; then
+    PKG_CHECK_MODULES([DRI3], [xcb x11-xcb xcb-dri3 \
+       xcb-sync xshmfence xcb-present], [USE_DRI3="yes"], [:])
+
+    if test "x$USE_DRI3" = "xno" -a "x$enable_dri3" = "xyes"; then
+       AC_MSG_ERROR([VA/X11-dri3 explicitly enabled, however $DRI3_PKG_ERRORS])
+    fi
+
+    if test "$USE_DRI3" = "yes"; then
+       AC_DEFINE([HAVE_VA_DRI3], [1], [Defined to 1 if VA/X11-DRI3 API is
+        enabled])
+    fi
+fi
+AM_CONDITIONAL(USE_DRI3, test "$USE_DRI3" = "yes")
+
 dnl Check for VA-API drivers path
 AC_ARG_VAR(LIBVA_DRIVERS_PATH, [drivers install path])
 if test -z "$LIBVA_DRIVERS_PATH"; then
@@ -197,6 +224,7 @@ AC_OUTPUT([
 dnl Print summary
 BACKENDS="drm"
 AS_IF([test "$USE_X11" = "yes"], [BACKENDS="$BACKENDS x11"])
+AS_IF([test "$USE_DRI3" = "yes"], [BACKENDS="$BACKENDS x11-dri3"])
 AS_IF([test "$USE_WAYLAND" = "yes"], [BACKENDS="$BACKENDS wayland"])
 
 echo

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,6 +47,9 @@ driver_libs = \
 	-lpthread -lm -ldl	\
 	$(DRM_LIBS)		\
 	$(NULL)
+if USE_DRI3
+driver_libs     += $(DRI3_LIBS)
+endif
 
 include Makefile.sources
 

--- a/src/i965_output_dri.c
+++ b/src/i965_output_dri.c
@@ -30,16 +30,61 @@
 #include "i965_output_dri.h"
 #include "dso_utils.h"
 
+#include <X11/Xlib-xcb.h>
+
 #define LIBVA_X11_NAME "libva-x11.so.2"
 
+#ifdef HAVE_VA_DRI3
+typedef int (*dri3_createfd_func)(VADriverContextP ctx,
+                                  Pixmap pixmap, int *stride);
+typedef Pixmap
+(*dri3_createPixmap_func)(VADriverContextP ctx, Drawable draw,
+                          int width, int height, int depth,
+                          int fd, int bpp, int stride, int size);
+typedef void
+(*dri3_presentPixmap_func)(VADriverContextP ctx, Drawable draw,
+                           Pixmap pixmap,
+                           unsigned int serial,
+                           xcb_xfixes_region_t valid,
+                           xcb_xfixes_region_t update,
+                           unsigned short int x_off,
+                           unsigned short int y_off,
+                           xcb_randr_crtc_t target_crtc,
+                           xcb_sync_fence_t wait_fence,
+                           xcb_sync_fence_t idle_fence,
+                           unsigned int options,
+                           unsigned long int target_msc,
+                           unsigned long int divisor,
+                           unsigned long int  remainder,
+                           unsigned int notifies_len,
+                           const xcb_present_notify_t *notifies);
+typedef int
+(*dri3_createfence_func)(VADriverContextP ctx, Pixmap pixmap,
+                         struct dri3_fence *fence);
+typedef void
+(*dri3_freefence_func)(VADriverContextP ctx,
+                       struct dri3_fence *fence);
+typedef void (*dri3_syncfence_func)(VADriverContextP ctx,
+                                    struct dri3_fence *fence);
+#else
 typedef struct dri_drawable *(*dri_get_drawable_func)(VADriverContextP ctx, XID drawable);
 typedef union dri_buffer *(*dri_get_rendering_buffer_func)(VADriverContextP ctx, struct dri_drawable *d);
 typedef void (*dri_swap_buffer_func)(VADriverContextP ctx, struct dri_drawable *d);
+#endif
 
 struct dri_vtable {
+#ifdef HAVE_VA_DRI3
+    dri3_createPixmap_func              createPixmap;
+    dri3_createfd_func                  createfd;
+    dri3_presentPixmap_func             presentPixmap;
+    dri3_createfence_func               createfence;
+    dri3_freefence_func                 freefence;
+    dri3_syncfence_func                 syncfence;
+#else
     dri_get_drawable_func               get_drawable;
     dri_get_rendering_buffer_func       get_rendering_buffer;
     dri_swap_buffer_func                swap_buffer;
+#endif
 };
 
 struct va_dri_output {
@@ -55,6 +100,33 @@ i965_output_dri_init(VADriverContextP ctx)
     struct dri_vtable *dri_vtable;
 
     static const struct dso_symbol symbols[] = {
+#ifdef HAVE_VA_DRI3
+        {
+            "va_dri3_createPixmap",
+            offsetof(struct dri_vtable, createPixmap)
+        },
+        {
+            "va_dri3_createfd",
+            offsetof(struct dri_vtable, createfd)
+        },
+        {
+            "va_dri3_presentPixmap",
+            offsetof(struct dri_vtable, presentPixmap)
+        },
+        {
+            "va_dri3_create_fence",
+            offsetof(struct dri_vtable, createfence)
+        },
+        {
+            "va_dri3_fence_free",
+            offsetof(struct dri_vtable, freefence)
+        },
+        {
+            "va_dri3_fence_sync",
+            offsetof(struct dri_vtable, syncfence)
+        },
+        { NULL, }
+#else
         {
             "va_dri_get_drawable",
             offsetof(struct dri_vtable, get_drawable)
@@ -68,6 +140,7 @@ i965_output_dri_init(VADriverContextP ctx)
             offsetof(struct dri_vtable, swap_buffer)
         },
         { NULL, }
+#endif
     };
 
     i965->dri_output = calloc(1, sizeof(struct va_dri_output));
@@ -122,15 +195,24 @@ i965_put_surface_dri(
     struct i965_driver_data * const i965 = i965_driver_data(ctx);
     struct dri_vtable * const dri_vtable = &i965->dri_output->vtable;
     struct i965_render_state * const render_state = &i965->render_state;
-    struct dri_drawable *dri_drawable;
-    union dri_buffer *buffer;
     struct intel_region *dest_region;
     struct object_surface *obj_surface;
-    uint32_t name;
     int i, ret;
+#ifndef HAVE_VA_DRI3
+    struct dri_drawable *dri_drawable;
+    union dri_buffer *buffer;
+    uint32_t name;
+#else
+    int bpp, x, y, fd;
+    Window root;
+    Pixmap pixmap;
+    struct dri3_fence fence;
+    unsigned int border, depth, stride, size, width, height;
+#endif
 
     /* Currently don't support DRI1 */
-    if (!VA_CHECK_DRM_AUTH_TYPE(ctx, VA_DRM_AUTH_DRI2))
+    if (!(VA_CHECK_DRM_AUTH_TYPE(ctx, VA_DRM_AUTH_DRI2) ||
+            VA_CHECK_DRM_AUTH_TYPE(ctx, VA_DRM_AUTH_CUSTOM)))
         return VA_STATUS_ERROR_UNKNOWN;
 
     /* Some broken sources such as H.264 conformance case FM2_SVA_C
@@ -146,11 +228,13 @@ i965_put_surface_dri(
 
     _i965LockMutex(&i965->render_mutex);
 
+#ifndef HAVE_VA_DRI3
     dri_drawable = dri_vtable->get_drawable(ctx, (Drawable)draw);
     ASSERT_RET(dri_drawable, VA_STATUS_ERROR_ALLOCATION_FAILED);
 
     buffer = dri_vtable->get_rendering_buffer(ctx, dri_drawable);
     ASSERT_RET(buffer, VA_STATUS_ERROR_ALLOCATION_FAILED);
+#endif
 
     dest_region = render_state->draw_region;
     if (dest_region == NULL) {
@@ -159,6 +243,23 @@ i965_put_surface_dri(
         render_state->draw_region = dest_region;
     }
 
+#ifdef HAVE_VA_DRI3
+    XGetGeometry(ctx->native_dpy, (Window)draw, &root,
+                 &x, &y, &width, &height, &border, &depth);
+
+    switch(depth) {
+        case 8: bpp = 8; break;
+        case 15: case 16: bpp = 16; break;
+        case 24: case 32: bpp = 32; break;
+        default: return VA_STATUS_ERROR_INVALID_VALUE;
+    }
+
+    stride = obj_surface->width * bpp/8;
+    size = ALIGN((stride * obj_surface->height) , 0x1000);
+
+    dest_region->cpp = bpp/8;
+    dest_region->pitch = stride;
+#else
     if (dest_region->bo) {
         dri_bo_flink(dest_region->bo, &name);
         if (buffer->dri2.name != name) {
@@ -166,22 +267,57 @@ i965_put_surface_dri(
             dest_region->bo = NULL;
         }
     }
+#endif
 
     if (dest_region->bo == NULL) {
+#ifdef HAVE_VA_DRI3
+        dest_region->bo =
+            drm_intel_bo_alloc(i965->intel.bufmgr,
+                               "prime", size, 0x1000);
+#else
         dest_region->cpp = buffer->dri2.cpp;
         dest_region->pitch = buffer->dri2.pitch;
+        dest_region->bo =
+            intel_bo_gem_create_from_name(i965->intel.bufmgr,
+                                          "rendering buffer",
+                                          buffer->dri2.name);
+#endif
+        ASSERT_RET(dest_region->bo, VA_STATUS_ERROR_ALLOCATION_FAILED);
 
-        dest_region->bo = intel_bo_gem_create_from_name(i965->intel.bufmgr, "rendering buffer", buffer->dri2.name);
-        ASSERT_RET(dest_region->bo, VA_STATUS_ERROR_UNKNOWN);
-
-        ret = dri_bo_get_tiling(dest_region->bo, &(dest_region->tiling), &(dest_region->swizzle));
+        ret = dri_bo_get_tiling(dest_region->bo,
+                                &(dest_region->tiling),
+                                &(dest_region->swizzle));
         ASSERT_RET((ret == 0), VA_STATUS_ERROR_UNKNOWN);
     }
 
+#ifdef HAVE_VA_DRI3
+    if(drm_intel_bo_gem_export_to_prime(dest_region->bo, &fd) != 0) {
+        fd = -1;
+        return VA_STATUS_ERROR_OPERATION_FAILED;
+    }
+
+    dest_region->height = obj_surface->orig_height;
+    dest_region->width = obj_surface->orig_width;
+    dest_region->x = src_rect->x;
+    dest_region->y = src_rect->y;
+    obj_surface->exported_primefd = fd;
+
+    xcb_connection_t *xcbconn = XGetXCBConnection(ctx->native_dpy);
+
+    if (dri_vtable->createfence(ctx, (Window)draw, &fence))
+        return VA_STATUS_ERROR_OPERATION_FAILED;
+
+    dri_vtable->syncfence(ctx, &fence);
+
+    pixmap = dri_vtable->createPixmap(ctx, root, dest_region->width,
+                                      dest_region->height, depth, fd,
+                                      bpp, stride, dest_region->bo->size);
+#else
     dest_region->x = dri_drawable->x;
     dest_region->y = dri_drawable->y;
     dest_region->width = dri_drawable->width;
     dest_region->height = dri_drawable->height;
+#endif
 
     if (!(flags & VA_SRC_COLOR_MASK))
         flags |= VA_SRC_BT601;
@@ -195,10 +331,20 @@ i965_put_surface_dri(
             intel_render_put_subpicture(ctx, obj_surface, src_rect, dst_rect);
         }
     }
+#ifdef HAVE_VA_DRI3
+    dri_vtable->presentPixmap(ctx, (Window)draw, pixmap,
+                              0 , 0, 0, 0, 0,
+                              None, None, fence.xid,
+                              XCB_PRESENT_OPTION_NONE,
+                              0 , 0, 0, 0, NULL);
 
+    xcb_free_pixmap(xcbconn, pixmap);
+    xcb_flush(xcbconn);
+    dri_vtable->freefence(ctx, &fence);
+#else
     if (!(g_intel_debug_option_flags & VA_INTEL_DEBUG_OPTION_BENCH))
         dri_vtable->swap_buffer(ctx, dri_drawable);
-
+#endif
     _i965UnlockMutex(&i965->render_mutex);
 
     return VA_STATUS_SUCCESS;


### PR DESCRIPTION
XWayland was failing to function with DRI2 as by default gnome shell supports DRI3 only whereas libva only supported dri2.
https://github.com/intel/libva/issues/79

This pull request enables dri3 support for driver.

Dependency: https://github.com/intel/libva/pull/180 
Usage: --enable-dri3 flags is added in config to enable this feature.