### PR TITLE
Use the new link URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,13 +42,13 @@ before_install:
   - sudo apt-get install -y intel-gpu-tools
  
 install:
-  - git clone https://github.com/01org/libva.git
+  - git clone https://github.com/intel/libva.git
   - (cd libva && ./autogen.sh && ./configure --prefix=/usr && sudo make install)
 
 addons:
   coverity_scan:
     project:
-      name: "01org/intel-vaapi-driver"
+      name: "intel/intel-vaapi-driver"
       description: "Build submitted via Travis CI"
     notification_email: intel-media-security@lists.01.org
     build_command_prepend: "./autogen.sh; ./configure --prefix=/usr"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,11 @@ We accept github pull requests.
 
 Once you've finished making your changes push them to your fork and send the PR via the github UI.
 
-## Issue tracking
+## Reporting a security issue
+
+Please mail to secure-opensource@intel.com directly for security issue
+
+## Public issue tracking
 
 If you have a problem, please let us know.  IRC is a perfectly fine place
 to quickly informally bring something up, if you get a response.  The
@@ -84,14 +88,14 @@ to quickly informally bring something up, if you get a response.  The
 is a more durable communication channel.
 
 If it's a bug not already documented, by all means please [open an
-issue in github](https://github.com/01org/intel-vaapi-driver/issues/new) so we all get visibility
+issue in github](https://github.com/intel/intel-vaapi-driver/issues/new) so we all get visibility
 to the problem and can work towards a resolution.
 
 For feature requests we're also using github issues, with the label
 "enhancement".
 
 Our github bug/enhancement backlog and work queue are tracked in a
-[Intel vaapi driver waffle.io kanban](https://waffle.io/01org/intel-vaapi-driver).
+[Intel vaapi driver waffle.io kanban](https://waffle.io/intel/intel-vaapi-driver).
 
 ## Closing issues
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Stories in Ready](https://badge.waffle.io/01org/intel-vaapi-driver.png?label=ready&title=Ready)](http://waffle.io/01org/intel-vaapi-driver)
-[![Build Status](https://travis-ci.org/01org/intel-vaapi-driver.svg?branch=master)](https://travis-ci.org/01org/intel-vaapi-driver)
-[![Coverity Scan Build Status](https://scan.coverity.com/projects/11612/badge.svg)](https://scan.coverity.com/projects/01org-intel-vaapi-driver)
+[![Stories in Ready](https://badge.waffle.io/intel/intel-vaapi-driver.png?label=ready&title=Ready)](http://waffle.io/intel/intel-vaapi-driver)
+[![Build Status](https://travis-ci.org/intel/intel-vaapi-driver.svg?branch=master)](https://travis-ci.org/intel/intel-vaapi-driver)
+[![Coverity Scan Build Status](https://scan.coverity.com/projects/11612/badge.svg)](https://scan.coverity.com/projects/intel-intel-vaapi-driver)
 
 #Intel-vaapi-driver Project
 
@@ -17,10 +17,10 @@ commands to be sent to the i915 driver for exercising both hardware and shader f
 decode, encode, and processing.
 
 If you would like to contribute to intel-vaapi-driver, check our [Contributing
-guide](https://github.com/01org/intel-vaapi-driver/blob/master/CONTRIBUTING.md).
+guide](https://github.com/intel/intel-vaapi-driver/blob/master/CONTRIBUTING.md).
 
 We also recommend taking a look at the ['janitorial'
-bugs](https://github.com/01org/intel-vaapi-driver/issues?q=is%3Aopen+is%3Aissue+label%3AJanitorial)
+bugs](https://github.com/intel/intel-vaapi-driver/issues?q=is%3Aopen+is%3Aissue+label%3AJanitorial)
 in our list of open issues as these bugs can be solved without an
 extensive knowledge of intel-vaapi-driver.
 

--- a/configure.ac
+++ b/configure.ac
@@ -22,9 +22,9 @@ m4_define([wayland_api_version], [1.11.0])
 AC_PREREQ([2.57])
 AC_INIT([intel_vaapi_driver],
         [intel_vaapi_driver_version],
-        [https://github.com/01org/intel-vaapi-driver/issues/new],
+        [https://github.com/intel/intel-vaapi-driver/issues/new],
         [intel-vaapi-driver],
-        [https://github.com/01org/intel-vaapi-driver])
+        [https://github.com/intel/intel-vaapi-driver])
 AC_CONFIG_SRCDIR([Makefile.am])
 AM_INIT_AUTOMAKE([1.9 tar-ustar -Wno-portability foreign])
 


### PR DESCRIPTION
We moved libva from github/01org to github/intel, however some files
still have links to the old 01org URLs, this commit updates these
links to the new intel URLs. In addition, this commit added a contact
email address for security issue reporting

This fixes https://github.com/intel/intel-vaapi-driver/issues/364
