### PR TITLE
Don't show an error on hybrid driver failure

### DIFF
--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -7492,7 +7492,7 @@ i965_initialize_wrapper(VADriverContextP ctx, const char *driver_name)
         i965->wrapper_pdrvctx = wrapper_pdrvctx;
         return VA_STATUS_SUCCESS;
     } else {
-        fprintf(stderr, "Failed to wrapper %s%s\n", driver_name, DRIVER_EXTENSION);
+        fprintf(stdout, "Not using %s%s\n", driver_name, DRIVER_EXTENSION);
         free(vtable);
         free(wrapper_pdrvctx);
         return VA_STATUS_ERROR_OPERATION_FAILED;


### PR DESCRIPTION
Distribution wants to have situation where both
hybrid/i965 drivers are avaible. Even when only the latter
is relevant on a given hardware.

Signed-off-by: Nicolas Chauvet <kwizart@gmail.com>