### PR TITLE
wayland : Enable support for RGBx texture format

### DIFF
--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -1897,7 +1897,7 @@ i965_suface_external_memory(VADriverContextP ctx,
     return VA_STATUS_SUCCESS;
 }
 
-static VAStatus
+VAStatus
 i965_CreateSurfaces2(
     VADriverContextP    ctx,
     unsigned int        format,

--- a/src/i965_internal_decl.h
+++ b/src/i965_internal_decl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Intel Corporation. All Rights Reserved.
+ * Copyright (C) 2018 Intel Corporation. All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the
@@ -25,7 +25,10 @@
 #ifndef I965_INTERNAL_DECL_H
 #define I965_INTERNAL_DECL_H
 
+#ifdef __cplusplus
 extern "C" {
+#endif
+
     #include "sysdeps.h"
     #include "i965_drv_video.h"
     #include "i965_encoder.h"
@@ -70,9 +73,20 @@ extern "C" {
     extern VAStatus i965_SyncSurface(
         VADriverContextP, VASurfaceID);
 
+    extern VAStatus i965_GetConfigAttributes(
+        VADriverContextP, VAProfile, VAEntrypoint,
+        VAConfigAttrib *, int);
+
+    extern VAStatus i965_CreateSurfaces2(
+        VADriverContextP, unsigned int, unsigned int,
+        unsigned int, VASurfaceID*, unsigned int,
+        VASurfaceAttrib*, unsigned int);
+
     extern struct hw_codec_info *i965_get_codec_info(int);
     extern const struct intel_device_info *i965_get_device_info(int);
 
-} // extern "C"
+#ifdef __cplusplus
+} //extern "C"
+#endif
 
 #endif

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -45,7 +45,6 @@ noinst_PROGRAMS = test_i965_drv_video
 noinst_HEADERS =							\
 	i965_avce_test_common.h						\
 	i965_config_test.h						\
-	i965_internal_decl.h						\
 	i965_jpeg_test_data.h						\
 	i965_streamable.h						\
 	i965_test_environment.h						\


### PR DESCRIPTION
Wayland mutter compositor supports only RGB textures whereas
intel-vaapi-driver was exporting only YUV textures. Enabling
RGBx texture by driver allows downstream media components
to utilize RGB surfaces.

Partial fix for https://github.com/intel/intel-vaapi-driver/issues/357
gst vaapisink requires vpp for RGB surface in addition of this patch as
mentioned in https://bugzilla.gnome.org/show_bug.cgi?id=775698#c15

Test: 
./gst-launch-1.0 -v videotestsrc pattern=colors ! video/x-raw, 
format=NV12, width=320, height=240, framerate=30/1 ! vaapipostproc ! 
video/x-raw, format=RGBx ! vaapisink

./gst-launch-1.0 filesrc location=320x240_50f_30fps.rgbx ! videoparse 
format=rgbx width=320 height=240 framerate=30/1 ! videoconvert ! vaapisink

Signed-off-by: Jayesh Kumar Tank <jayesh.kumarx.tank@intel.com>