### PR TITLE
genX_mfd: ignore FASTUVMC for interlace frame P and B pictures

### DIFF
--- a/src/gen75_mfd.c
+++ b/src/gen75_mfd.c
@@ -2140,12 +2140,17 @@ gen75_mfd_vc1_pic_state(VADriverContextP ctx,
         }
     }
 
-    if (pic_param->mv_fields.bits.mv_mode == VAMvMode1MvHalfPelBilinear ||
-        (pic_param->mv_fields.bits.mv_mode == VAMvModeIntensityCompensation &&
-         pic_param->mv_fields.bits.mv_mode2 == VAMvMode1MvHalfPelBilinear))
-        interpolation_mode = 8 | pic_param->fast_uvmc_flag;
-    else
-        interpolation_mode = 0 | pic_param->fast_uvmc_flag;
+    if ((!pic_param->sequence_fields.bits.interlace ||
+         pic_param->picture_fields.bits.frame_coding_mode != 1) && /* Progressive or Field-Interlace */
+        (picture_type == GEN7_VC1_P_PICTURE ||
+         picture_type == GEN7_VC1_B_PICTURE)) {
+        if (pic_param->mv_fields.bits.mv_mode == VAMvMode1MvHalfPelBilinear ||
+            (pic_param->mv_fields.bits.mv_mode == VAMvModeIntensityCompensation &&
+             pic_param->mv_fields.bits.mv_mode2 == VAMvMode1MvHalfPelBilinear))
+            interpolation_mode = 8 | pic_param->fast_uvmc_flag;
+        else
+            interpolation_mode = 0 | pic_param->fast_uvmc_flag;
+    }
 
     BEGIN_BCS_BATCH(batch, 6);
     OUT_BCS_BATCH(batch, MFD_VC1_LONG_PIC_STATE | (6 - 2));

--- a/src/gen7_mfd.c
+++ b/src/gen7_mfd.c
@@ -1874,12 +1874,17 @@ gen7_mfd_vc1_pic_state(VADriverContextP ctx,
         }
     }
 
-    if (pic_param->mv_fields.bits.mv_mode == VAMvMode1MvHalfPelBilinear ||
-        (pic_param->mv_fields.bits.mv_mode == VAMvModeIntensityCompensation &&
-         pic_param->mv_fields.bits.mv_mode2 == VAMvMode1MvHalfPelBilinear))
-        interpolation_mode = 8 | pic_param->fast_uvmc_flag;
-    else
-        interpolation_mode = 0 | pic_param->fast_uvmc_flag;
+    if ((!pic_param->sequence_fields.bits.interlace ||
+         pic_param->picture_fields.bits.frame_coding_mode != 1) && /* Progressive or Field-Interlace */
+        (picture_type == GEN7_VC1_P_PICTURE ||
+         picture_type == GEN7_VC1_B_PICTURE)) {
+        if (pic_param->mv_fields.bits.mv_mode == VAMvMode1MvHalfPelBilinear ||
+            (pic_param->mv_fields.bits.mv_mode == VAMvModeIntensityCompensation &&
+             pic_param->mv_fields.bits.mv_mode2 == VAMvMode1MvHalfPelBilinear))
+            interpolation_mode = 8 | pic_param->fast_uvmc_flag;
+        else
+            interpolation_mode = 0 | pic_param->fast_uvmc_flag;
+    }
 
     BEGIN_BCS_BATCH(batch, 6);
     OUT_BCS_BATCH(batch, MFD_VC1_LONG_PIC_STATE | (6 - 2));

--- a/src/gen8_mfd.c
+++ b/src/gen8_mfd.c
@@ -1919,12 +1919,17 @@ gen8_mfd_vc1_pic_state(VADriverContextP ctx,
         }
     }
 
-    if (pic_param->mv_fields.bits.mv_mode == VAMvMode1MvHalfPelBilinear ||
-        (pic_param->mv_fields.bits.mv_mode == VAMvModeIntensityCompensation &&
-         pic_param->mv_fields.bits.mv_mode2 == VAMvMode1MvHalfPelBilinear))
-        interpolation_mode = 8 | pic_param->fast_uvmc_flag;
-    else
-        interpolation_mode = 0 | pic_param->fast_uvmc_flag;
+    if ((!pic_param->sequence_fields.bits.interlace ||
+         pic_param->picture_fields.bits.frame_coding_mode != 1) && /* Progressive or Field-Interlace */
+        (picture_type == GEN7_VC1_P_PICTURE ||
+         picture_type == GEN7_VC1_B_PICTURE)) {
+        if (pic_param->mv_fields.bits.mv_mode == VAMvMode1MvHalfPelBilinear ||
+            (pic_param->mv_fields.bits.mv_mode == VAMvModeIntensityCompensation &&
+             pic_param->mv_fields.bits.mv_mode2 == VAMvMode1MvHalfPelBilinear))
+            interpolation_mode = 8 | pic_param->fast_uvmc_flag;
+        else
+            interpolation_mode = 0 | pic_param->fast_uvmc_flag;
+    }
 
     BEGIN_BCS_BATCH(batch, 6);
     OUT_BCS_BATCH(batch, MFD_VC1_LONG_PIC_STATE | (6 - 2));


### PR DESCRIPTION
This patch corrects a small deviation from VC-1 spec and fixes a decoding
inaccuracy that could occur when the application using this driver sets
MVMODE or MVMODE2 to a nonzero value in interlace frame P and B pictures.

Interlace frame P and B pictures should ignore the FASTUVMC syntax element, as
stated in section 10.7.3.7 of VC-1 spec. Furthermore, prevent using the MVMODE
syntax element for interlace frame P and B pictures, as these picture types do
not include MVMODE or MVMODE2.

Signed-off-by: Jerome Borsboom <jerome.borsboom@carpalis.nl>