### PR TITLE
vp8 encoder parameter check - do not check for ref frames if no no_re…

### DIFF
--- a/src/i965_encoder.c
+++ b/src/i965_encoder.c
@@ -1154,32 +1154,39 @@ intel_encoder_check_vp8_parameter(VADriverContextP ctx,
     encode_state->coded_buf_object = obj_buffer;
 
     if (!is_key_frame) {
-        assert(pic_param->ref_last_frame != VA_INVALID_SURFACE);
-        obj_surface = SURFACE(pic_param->ref_last_frame);
-        assert(obj_surface && obj_surface->bo);
 
-        if (!obj_surface || !obj_surface->bo)
-            goto error;
+        if(!pic_param->ref_flags.bits.no_ref_last) {
+            assert(pic_param->ref_last_frame != VA_INVALID_SURFACE);
+            obj_surface = SURFACE(pic_param->ref_last_frame);
+            assert(obj_surface && obj_surface->bo);
 
-        encode_state->reference_objects[i++] = obj_surface;
+            if (!obj_surface || !obj_surface->bo)
+                goto error;
 
-        assert(pic_param->ref_gf_frame != VA_INVALID_SURFACE);
-        obj_surface = SURFACE(pic_param->ref_gf_frame);
-        assert(obj_surface && obj_surface->bo);
+            encode_state->reference_objects[i++] = obj_surface;
+        }
 
-        if (!obj_surface || !obj_surface->bo)
-            goto error;
+        if(!pic_param->ref_flags.bits.no_ref_gf) {
+            assert(pic_param->ref_gf_frame != VA_INVALID_SURFACE);
+            obj_surface = SURFACE(pic_param->ref_gf_frame);
+            assert(obj_surface && obj_surface->bo);
 
-        encode_state->reference_objects[i++] = obj_surface;
+            if (!obj_surface || !obj_surface->bo)
+                goto error;
 
-        assert(pic_param->ref_arf_frame != VA_INVALID_SURFACE);
-        obj_surface = SURFACE(pic_param->ref_arf_frame);
-        assert(obj_surface && obj_surface->bo);
+            encode_state->reference_objects[i++] = obj_surface;
+        }
 
-        if (!obj_surface || !obj_surface->bo)
-            goto error;
+        if(!pic_param->ref_flags.bits.no_ref_arf) {
+            assert(pic_param->ref_arf_frame != VA_INVALID_SURFACE);
+            obj_surface = SURFACE(pic_param->ref_arf_frame);
+            assert(obj_surface && obj_surface->bo);
 
-        encode_state->reference_objects[i++] = obj_surface;
+            if (!obj_surface || !obj_surface->bo)
+                goto error;
+
+            encode_state->reference_objects[i++] = obj_surface;
+        }
     }
 
     for (; i < 16; i++)

--- a/src/i965_encoder.c
+++ b/src/i965_encoder.c
@@ -1139,14 +1139,12 @@ intel_encoder_check_vp8_parameter(VADriverContextP ctx,
     int is_key_frame = !pic_param->pic_flags.bits.frame_type;
 
     obj_surface = SURFACE(pic_param->reconstructed_frame);
-    assert(obj_surface); /* It is possible the store buffer isn't allocated yet */
 
     if (!obj_surface)
         goto error;
 
     encode_state->reconstructed_object = obj_surface;
     obj_buffer = BUFFER(pic_param->coded_buf);
-    assert(obj_buffer && obj_buffer->buffer_store && obj_buffer->buffer_store->bo);
 
     if (!obj_buffer || !obj_buffer->buffer_store || !obj_buffer->buffer_store->bo)
         goto error;
@@ -1155,37 +1153,37 @@ intel_encoder_check_vp8_parameter(VADriverContextP ctx,
 
     if (!is_key_frame) {
 
-        if(!pic_param->ref_flags.bits.no_ref_last) {
-            assert(pic_param->ref_last_frame != VA_INVALID_SURFACE);
+        if (!pic_param->ref_flags.bits.no_ref_last) {
             obj_surface = SURFACE(pic_param->ref_last_frame);
-            assert(obj_surface && obj_surface->bo);
 
             if (!obj_surface || !obj_surface->bo)
                 goto error;
 
             encode_state->reference_objects[i++] = obj_surface;
+        } else {
+            encode_state->reference_objects[i++] = NULL;
         }
 
-        if(!pic_param->ref_flags.bits.no_ref_gf) {
-            assert(pic_param->ref_gf_frame != VA_INVALID_SURFACE);
+        if (!pic_param->ref_flags.bits.no_ref_gf) {
             obj_surface = SURFACE(pic_param->ref_gf_frame);
-            assert(obj_surface && obj_surface->bo);
 
             if (!obj_surface || !obj_surface->bo)
                 goto error;
 
             encode_state->reference_objects[i++] = obj_surface;
+        } else {
+            encode_state->reference_objects[i++] = NULL;
         }
 
-        if(!pic_param->ref_flags.bits.no_ref_arf) {
-            assert(pic_param->ref_arf_frame != VA_INVALID_SURFACE);
+        if (!pic_param->ref_flags.bits.no_ref_arf) {
             obj_surface = SURFACE(pic_param->ref_arf_frame);
-            assert(obj_surface && obj_surface->bo);
 
             if (!obj_surface || !obj_surface->bo)
                 goto error;
 
             encode_state->reference_objects[i++] = obj_surface;
+        } else {
+            encode_state->reference_objects[i++] = NULL;
         }
     }
 

--- a/src/i965_encoder_vp8.c
+++ b/src/i965_encoder_vp8.c
@@ -4373,8 +4373,8 @@ i965_encoder_vp8_vme_mpu_set_curbe(VADriverContextP ctx,
     pcmd->dw1.sharpness_level = pic_param->sharpness_level;
     pcmd->dw1.loop_filter_adjustment_on = pic_param->pic_flags.bits.loop_filter_adj_enable;
     pcmd->dw1.mb_no_coeffiscient_skip = pic_param->pic_flags.bits.mb_no_coeff_skip;
-    pcmd->dw1.golden_reference_copy_flag = pic_param->pic_flags.bits.copy_buffer_to_golden;
-    pcmd->dw1.alternate_reference_copy_flag = pic_param->pic_flags.bits.copy_buffer_to_alternate;
+    pcmd->dw1.golden_reference_copy_flag = ((pic_param->pic_flags.bits.refresh_golden_frame == 1) ? 3 : pic_param->pic_flags.bits.copy_buffer_to_golden);
+    pcmd->dw1.alternate_reference_copy_flag = ((pic_param->pic_flags.bits.refresh_alternate_frame == 1) ? 3 : pic_param->pic_flags.bits.copy_buffer_to_alternate);
     pcmd->dw1.last_frame_update = pic_param->pic_flags.bits.refresh_last;
     pcmd->dw1.sign_bias_golden = pic_param->pic_flags.bits.sign_bias_golden;
     pcmd->dw1.sign_bias_alt_ref = pic_param->pic_flags.bits.sign_bias_alternate;


### PR DESCRIPTION
…f_X flag is set

In VP8 encoding not always all reference frames (last, golden, altref) are provided.
This is indicated with the flags ref_flags.bits.no_ref_last, ref_flags.bits.no_ref_gf
and ref_flags.bits.no_ref_arf in VAEncPictureParameterBufferVP8.
While checking picture parameters, make sure that assert errors concerning invalid
reference frame only occure if no_ref_X is not set.