### PR TITLE
965_drv_video: fix decoding error when last macroblock is skipped

### DIFF
--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -2918,7 +2918,7 @@ i965_create_buffer_internal(VADriverContextP ctx,
         else
             buffer_store->bo = dri_bo_alloc(i965->intel.bufmgr,
                                             "Buffer",
-                                            size * num_elements, 64);
+                                            size * num_elements + 1, 64);
         assert(buffer_store->bo);
 
         /* If the buffer is wrapped, the bo/buffer of buffer_store is bogus.


### PR DESCRIPTION
When the last macroblock in a picture is a skipped macroblock, the macroblock is not coded with any bits, and no more bits remain in the slice buffer, this block is not written to the output
in some cases. This patch gives one byte headroom in the slice buffer which
resolves the decoding errors.

I am not fully sure if the issue is a read beyond the end of the slice data buffer, but without this patch I cannot get the SSL0015 VC-1 test file to decode bit-exact to the reference decoder.

Signed-off-by: Jerome Borsboom <jerome.borsboom@carpalis.nl>