### PR TITLE
enable vp8 multiple BRC pass

### DIFF
--- a/src/i965_encoder_vp8.c
+++ b/src/i965_encoder_vp8.c
@@ -1367,12 +1367,6 @@ i965_encoder_vp8_read_pak_statistics(VADriverContextP ctx,
     mi_store_register_mem_param.mmio_offset = vp8_context->vdbox_mmio_base + VP8_MFC_BITSTREAM_BYTECOUNT_FRAME_REG_OFFSET;
     gpe->mi_store_register_mem(ctx, batch, &mi_store_register_mem_param);
 
-    if (ipass == 0) {
-        mi_store_register_mem_param.offset = sizeof(unsigned int) * 4;
-        mi_store_register_mem_param.mmio_offset = vp8_context->vdbox_mmio_base + VP8_MFX_BRC_CUMULATIVE_DQ_INDEX01_REG_OFFSET;
-        gpe->mi_store_register_mem(ctx, batch, &mi_store_register_mem_param);
-    }
-
     mi_store_register_mem_param.offset = sizeof(unsigned int) * 5;
     mi_store_register_mem_param.mmio_offset = vp8_context->vdbox_mmio_base + VP8_MFX_BRC_DQ_INDEX_REG_OFFSET;
     gpe->mi_store_register_mem(ctx, batch, &mi_store_register_mem_param);
@@ -1380,6 +1374,12 @@ i965_encoder_vp8_read_pak_statistics(VADriverContextP ctx,
     mi_store_register_mem_param.offset = sizeof(unsigned int) * 6;
     mi_store_register_mem_param.mmio_offset = vp8_context->vdbox_mmio_base + VP8_MFX_BRC_D_LOOP_FILTER_REG_OFFSET;
     gpe->mi_store_register_mem(ctx, batch, &mi_store_register_mem_param);
+
+    if (ipass == 0) {
+        mi_store_register_mem_param.offset = sizeof(unsigned int) * 4;
+        mi_store_register_mem_param.mmio_offset = vp8_context->vdbox_mmio_base + VP8_MFX_BRC_CUMULATIVE_DQ_INDEX01_REG_OFFSET;
+        gpe->mi_store_register_mem(ctx, batch, &mi_store_register_mem_param);
+    }
 
     mi_store_register_mem_param.offset = sizeof(unsigned int) * 9;
     mi_store_register_mem_param.mmio_offset = vp8_context->vdbox_mmio_base + VP8_MFX_BRC_CUMULATIVE_DQ_INDEX01_REG_OFFSET;

--- a/src/i965_encoder_vp8.c
+++ b/src/i965_encoder_vp8.c
@@ -5502,6 +5502,7 @@ i965_encoder_vp8_pak_insert_batch_buffers(VADriverContextP ctx, struct intel_enc
     }
 
     batch_param.bo = vp8_context->mb_coded_buffer.bo;
+    batch_param.offset = 0;
     gpe->mi_batch_buffer_start(ctx, batch, &batch_param);
 }
 

--- a/src/i965_encoder_vp8.c
+++ b/src/i965_encoder_vp8.c
@@ -5119,7 +5119,7 @@ i965_encoder_vp8_vme_var_init(VADriverContextP ctx,
     vp8_context->brc_distortion_buffer_supported = 1;
     vp8_context->brc_constant_buffer_supported = 1;
     vp8_context->repak_supported = 1;
-    vp8_context->multiple_pass_brc_supported = 0;
+    vp8_context->multiple_pass_brc_supported = 1;
     vp8_context->is_first_frame = 1;
     vp8_context->is_first_two_frame = 1;
     vp8_context->gop_size = 30;

--- a/src/i965_encoder_vp8.c
+++ b/src/i965_encoder_vp8.c
@@ -2355,8 +2355,8 @@ i965_encoder_vp8_vme_brc_init_reset_set_curbe(VADriverContextP ctx,
     bps_ratio = input_bits_per_frame / ((double)(pcmd->dw2.buf_size_in_bits) / 30);
     bps_ratio = (bps_ratio < 0.1) ? 0.1 : (bps_ratio > 3.5) ? 3.5 : bps_ratio;
 
-    pcmd->dw9.frame_width_in_bytes = vp8_context->frame_width;
-    pcmd->dw10.frame_height_in_bytes = vp8_context->frame_height;
+    pcmd->dw9.frame_width_in_bytes = vp8_context->picture_width;
+    pcmd->dw10.frame_height_in_bytes = vp8_context->picture_height;
     pcmd->dw10.avbr_accuracy = 30;
     pcmd->dw11.avbr_convergence = 150;
     pcmd->dw11.min_qp = pic_param->clamp_qindex_low;

--- a/src/i965_encoder_vp8.h
+++ b/src/i965_encoder_vp8.h
@@ -2407,7 +2407,6 @@ struct vp8_encode_status {
     uint32_t bitstream_byte_count_per_frame;
     uint32_t pad0;
     uint32_t image_status_mask;
-    uint32_t pad1;
     struct vp8_vdbox_image_status_control image_status_ctrl;
     uint32_t pad2;
 };


### PR DESCRIPTION
This patches fixes some VP8 issues for multiple BRC pass, then enable multiple BRC pass by default