### PR TITLE
Watchdog i965 media driver changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ m4_append([intel_vaapi_driver_version], intel_vaapi_driver_pre_version, [.pre])
 m4_define([va_api_version], [1.1.0])
 
 # libdrm minimum version requirement
-m4_define([libdrm_version], [2.4.52])
+m4_define([libdrm_version], [2.4.75])
 
 # Wayland minimum version requirement
 # 1.11.0 for wl_proxy_create_wrapper

--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -2744,13 +2744,17 @@ i965_CreateContext(VADriverContextP ctx,
     i965->current_context_id = contextID;
 
     i965->bufmgr = drm_intel_bufmgr_gem_init(intel->fd, 4096);
-
+    assert(i965->bufmgr);
     i965->gem_context = drm_intel_gem_context_create(i965->bufmgr);
+    assert(i965->gem_context);
     intel->gem_context = i965->gem_context;
     intel->gem_ctx_id = i965->gem_context->ctx_id;
 
     if (kernel_has_gpu_watchdog_support(&i965->intel))
         i965->intel.has_watchdog = 1;
+
+    if (i965->intel.has_watchdog)
+        set_watchdog_timer_threshold(&i965->intel, picture_width, picture_height);
 
     return vaStatus;
 }
@@ -2777,6 +2781,7 @@ i965_DestroyContext(VADriverContextP ctx, VAContextID context)
     }
 
     drm_intel_gem_context_destroy(i965->gem_context);
+    drm_intel_bufmgr_destroy(i965->bufmgr);
 
     i965->intel.has_watchdog = 0;
 

--- a/src/i965_drv_video.h
+++ b/src/i965_drv_video.h
@@ -547,6 +547,9 @@ struct i965_driver_data {
     VADisplayAttribute *saturation_attrib;
     VAContextID current_context_id;
 
+    drm_intel_bufmgr *bufmgr;
+    drm_intel_context *gem_context;
+
     /* VA/DRI (X11) specific data */
     struct va_dri_output *dri_output;
 

--- a/src/intel_batchbuffer.c
+++ b/src/intel_batchbuffer.c
@@ -146,11 +146,17 @@ intel_batchbuffer_flush(struct intel_batchbuffer *batch)
     used = batch->ptr - batch->map;
 
     if (batch->intel->has_watchdog)
-        intel_batchbuffer_configure_watchdog(batch->intel->fd, batch->intel->gem_ctx_id, batch->flag);
+        intel_batchbuffer_configure_watchdog(batch->intel, batch->intel->gem_ctx_id, batch->flag);
 
-    /* FIXME: Add BSD2 ring on supported platforms */
-    if (ring_flag == I915_EXEC_BSD)
-        batch->flag |= LOCAL_I915_EXEC_BSD_RING0;
+    if (batch->intel->has_bsd2) {
+        if (ring_flag == I915_EXEC_BSD)
+            batch->flag |= LOCAL_I915_EXEC_BSD_RING0;
+        else if (ring_flag == (I915_EXEC_BSD_RING2 | I915_EXEC_BSD))
+            batch->flag |= LOCAL_I915_EXEC_BSD_RING1;
+    } else {
+        if (batch->flag == I915_EXEC_BSD)
+            batch->flag |= LOCAL_I915_EXEC_BSD_RING0;
+    }
 
     batch->run(batch->buffer, batch->intel->gem_context, used, -1, NULL, batch->flag);
 

--- a/src/intel_batchbuffer.h
+++ b/src/intel_batchbuffer.h
@@ -20,9 +20,13 @@ struct intel_batchbuffer {
     int emit_total;
     unsigned char *emit_start;
 
-    int (*run)(drm_intel_bo *bo, int used,
-               drm_clip_rect_t *cliprects, int num_cliprects,
-               int DR4, unsigned int ring_flag);
+    /* Media reset timeout for this buffer in ms */
+    unsigned long watchdog_threshold;
+
+    int (*run)(drm_intel_bo *bo,
+               drm_intel_context *ctx,
+               int used, int in_fence,
+               int *out_fence, unsigned int flags);
 
     /* Used for Sandybdrige workaround */
     dri_bo *wa_render_bo;

--- a/src/intel_driver.h
+++ b/src/intel_driver.h
@@ -112,8 +112,12 @@ extern uint32_t g_intel_debug_option_flags;
 #define VA_INTEL_DEBUG_OPTION_DUMP_AUB  (1 << 2)
 
 #define LOCAL_I915_CONTEXT_PARAM_WATCHDOG 0x7
-#define LOCAL_I915_EXEC_VEBOX             (4<<0)
 #define LOCAL_I915_EXEC_VCS2              (5<<0)
+
+#define MHW_MI_16K_WATCHDOG_THRESHOLD_IN_MS        2000
+#define MHW_MI_8K_WATCHDOG_THRESHOLD_IN_MS         500
+#define MHW_MI_4K_WATCHDOG_THRESHOLD_IN_MS         100
+#define MHW_MI_FHD_WATCHDOG_THRESHOLD_IN_MS        50
 
 typedef enum _gen_gpu_class_engine {
     RENDER_CLASS = 0,
@@ -197,6 +201,7 @@ struct intel_driver_data {
     dri_bufmgr *bufmgr;
     unsigned int gem_ctx_id;
     drm_intel_context *gem_context;
+    unsigned int watchdog_threshold_in_ms;
 
     unsigned int has_exec2  : 1; /* Flag: has execbuffer2? */
     unsigned int has_bsd    : 1; /* Flag: has bitstream decoder for H.264? */
@@ -215,13 +220,13 @@ struct intel_driver_data {
 /* FIXME: this struct is currently private and part of libdrm */
 struct _drm_intel_context {
     unsigned int ctx_id;
-    struct _drm_intel_bufmgr *bufmgr;
 };
 
 bool intel_driver_init(VADriverContextP ctx);
 void intel_driver_terminate(VADriverContextP ctx);
-bool intel_batchbuffer_configure_watchdog(int fd, unsigned int ctx_id, int flag);
+bool intel_batchbuffer_configure_watchdog(struct intel_driver_data *intel, unsigned int ctx_id, int flag);
 bool kernel_has_gpu_watchdog_support(struct intel_driver_data *intel);
+bool set_watchdog_timer_threshold(struct intel_driver_data *intel, int picture_width, int picture_height);
 
 static INLINE struct intel_driver_data *
 intel_driver_data(VADriverContextP ctx)


### PR DESCRIPTION
This CL adds the ioctl necessary to set the watchdog timer
after each batch buffer is submitted.

This is part of the Timeout Detection and Recovery (TDR)
mechanism previously done here in upstream:
https://patchwork.freedesktop.org/series/21868/.

Tested-by: Carlos Santa <carlos.santa@intel.com>
Signed-off-by: Carlos Santa <carlos.santa@intel.com>