### PR TITLE
Fix meson build without wayland

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -91,7 +91,7 @@ if get_option('with_wayland') != 'no'
     version : libva_version,
     required : get_option('with_wayland') == 'yes')
 
-  WITH_WAYLAND = wl_scanner.found() and libva_wayland_dep.found()
+  WITH_WAYLAND = wayland_client_dep.found() and libva_wayland_dep.found()
 endif
 
 subdir('src')


### PR DESCRIPTION
Current 2.3.0 build with meson fails if wayland dependency isn't detected:
```
        Library dl found: YES
        Library m found: YES
        Program git found: NO
        Dependency threads found: YES 
        Found pkg-config: /usr/bin/pkg-config (1.5.3)
        Dependency libdrm found: YES 2.4.97
        Dependency libdrm_intel found: YES 2.4.97
        Dependency libva found: YES 1.3.0
        Dependency libva-x11 found: YES 1.3.0
        Found CMake: NO
        Dependency wayland-client found: NO (tried pkgconfig and cmake)
        Dependency libva-wayland found: NO (tried pkgconfig and cmake)

        meson.build:94:2: ERROR:  Unknown variable "wl_scanner".
```

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=235039