### PR TITLE
Return false instead of assertion failure

### DIFF
--- a/src/intel_driver.c
+++ b/src/intel_driver.c
@@ -123,7 +123,9 @@ intel_driver_init(VADriverContextP ctx)
     intel->locked = 0;
     pthread_mutex_init(&intel->ctxmutex, NULL);
 
-    intel_memman_init(intel);
+    if (!intel_memman_init(intel))
+        return false;
+
     intel->device_id = drm_intel_bufmgr_gem_get_devid(intel->bufmgr);
     intel->device_info = i965_get_device_info(intel->device_id);
 

--- a/src/intel_memman.c
+++ b/src/intel_memman.c
@@ -35,7 +35,10 @@ Bool
 intel_memman_init(struct intel_driver_data *intel)
 {
     intel->bufmgr = intel_bufmgr_gem_init(intel->fd, BATCH_SIZE);
-    assert(intel->bufmgr);
+
+    if (!intel->bufmgr)
+        return False;
+
     intel_bufmgr_gem_enable_reuse(intel->bufmgr);
 
     if (g_intel_debug_option_flags & VA_INTEL_DEBUG_OPTION_DUMP_AUB) {
@@ -50,6 +53,7 @@ intel_memman_init(struct intel_driver_data *intel)
 Bool
 intel_memman_terminate(struct intel_driver_data *intel)
 {
-    drm_intel_bufmgr_destroy(intel->bufmgr);
+    if (intel->bufmgr)
+        drm_intel_bufmgr_destroy(intel->bufmgr);
     return True;
 }


### PR DESCRIPTION
If so, the upper-layer application or library may handle the error.

This patch may fix the issue mentioned in https://gitlab.freedesktop.org/gstreamer/gstreamer-vaapi/issues/135