### PR TITLE
Fix compile warnings (errors) in Android 9

### DIFF
--- a/src/Android.mk
+++ b/src/Android.mk
@@ -60,7 +60,11 @@ $(GEN): $(LOCAL_PATH)/intel_version.h.in $(wildcard $(LOCAL_PATH)/../.git/logs/H
 	sed -e "s|\@INTEL_DRIVER_GIT_VERSION\@|$$VER|" $< > $@
 LOCAL_GENERATED_SOURCES += $(GEN)
 
-LOCAL_CFLAGS := -DLINUX -g -Wall -Wno-unused -fvisibility=hidden
+LOCAL_CFLAGS := -DLINUX -g -Wall -Wno-unused -fvisibility=hidden \
+	-Wno-missing-field-initializers \
+	-Wno-unused-parameter \
+	-Wno-pointer-arith \
+	-Wno-sign-compare \
 
 LOCAL_SHARED_LIBRARIES := libdl libdrm libdrm_intel libcutils \
                libva libva-android libstdc++
@@ -71,5 +75,3 @@ LOCAL_SHARED_LIBRARIES += liblog
 endif
 
 include $(BUILD_SHARED_LIBRARY)
-
-

--- a/src/gen75_vme.c
+++ b/src/gen75_vme.c
@@ -1070,6 +1070,7 @@ Bool gen75_vme_context_init(VADriverContextP ctx, struct intel_encoder_context *
     default:
         /* never get here */
         assert(0);
+        i965_kernel_num = 0;
 
         break;
     }

--- a/src/gen9_vme.c
+++ b/src/gen9_vme.c
@@ -2036,6 +2036,7 @@ Bool gen9_vme_context_init(VADriverContextP ctx, struct intel_encoder_context *e
     default:
         /* never get here */
         assert(0);
+        i965_kernel_num = 0;
 
         break;
     }


### PR DESCRIPTION
Android 9 enforces more stricter compile rules that treat most warnings as errors. The patches make the master branch buildable in Android 9.