### PR TITLE
Some ROI fixes

### DIFF
--- a/src/gen6_mfc_common.c
+++ b/src/gen6_mfc_common.c
@@ -2085,7 +2085,7 @@ intel_h264_enc_roi_config(VADriverContextP ctx,
 
     vme_context->roi_enabled = 0;
     /* Restriction: Disable ROI when multi-slice is enabled */
-    if (!encoder_context->context_roi || (encode_state->num_slice_params_ext > 1))
+    if (encode_state->num_slice_params_ext > 1)
         return;
 
     vme_context->roi_enabled = !!encoder_context->brc.num_roi;

--- a/src/gen6_mfc_common.c
+++ b/src/gen6_mfc_common.c
@@ -2126,7 +2126,7 @@ intel_h264_enc_roi_config(VADriverContextP ctx,
         memset(vme_context->qp_per_mb, qp, width_in_mbs * height_in_mbs);
 
 
-        for (j = num_roi; j ; j--) {
+        for (j = num_roi - 1; j >= 0; j--) {
             int qp_delta, qp_clip;
 
             col_start = encoder_context->brc.roi[j].left;


### PR DESCRIPTION
Tested with <https://lists.ffmpeg.org/pipermail/ffmpeg-devel/2019-February/240535.html>.  The lack of the EncROI attribute matches what the iHD driver does, too.