### PR TITLE
Fix compilation warnings.

### DIFF
--- a/src/sysdeps.h
+++ b/src/sysdeps.h
@@ -37,10 +37,12 @@
 
 #endif /* ANDROID */
 
+#define _GNU_SOURCE 1
+#include <string.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
-#include <string.h>
 #include <stdint.h>
 #include <assert.h>
 


### PR DESCRIPTION
In commit f6573cb7 memmem() call is introduced which is a GNU
extension, which need to be enabled explicitely, otherwise the
compiler will trigger a warning.

This patch enables globally the usage of GNU extensions.