### PR TITLE
wayland: Fix for FD leaks in case of invalid image format

### DIFF
--- a/src/i965_output_wayland.c
+++ b/src/i965_output_wayland.c
@@ -332,6 +332,8 @@ va_GetSurfaceBufferWl(
             drm_format = WL_DRM_FORMAT_YUV444;
             break;
         default:
+            if (fd != -1)
+                close(fd);
             return VA_STATUS_ERROR_INVALID_IMAGE_FORMAT;
         }
         offsets[0] = 0;
@@ -342,6 +344,8 @@ va_GetSurfaceBufferWl(
         pitches[2] = obj_surface->cb_cr_pitch;
         break;
     default:
+        if (fd != -1)
+            close(fd);
         return VA_STATUS_ERROR_INVALID_IMAGE_FORMAT;
     }
 


### PR DESCRIPTION
In the case the va_GetSurfaceBufferWl is not able to create a prime or planar buffer it will leak the FD get from DRM.