### PR TITLE
Green artefacts in WVC1 decoding with sandy bridge (gen6)

### DIFF
--- a/src/gen6_mfd.c
+++ b/src/gen6_mfd.c
@@ -1482,8 +1482,11 @@ gen6_mfd_vc1_pic_state(VADriverContextP ctx,
         loopfilter = pic_param->entrypoint_fields.bits.loopfilter;
     }
 
-    if (picture_type == GEN6_VC1_I_PICTURE || picture_type == GEN6_VC1_BI_PICTURE) /* I picture */
+    if (picture_type == GEN6_VC1_I_PICTURE || picture_type == GEN6_VC1_BI_PICTURE) { /* I picture */
         trans_ac_y = pic_param->transform_fields.bits.transform_ac_codingset_idx2;
+        if (pic_param->sequence_fields.bits.profile == 3) /* Advanced Profile */
+            ptype = GEN6_VC1_BI_PICTURE;
+    }
     else {
         trans_ac_y = pic_param->transform_fields.bits.transform_ac_codingset_idx1;
         /*


### PR DESCRIPTION
Since commit 1591f6c1be689c5265cb5beab18c97771d056cb9 WVC1 videos are decoded with a green color on sandy bridge platforms.
This is because of a wrong ptype before this commit ptype was set to GEN6_VC1_BI_PICTURE if picture_type is GEN6_VC1_I_PICTURE and profile is advanced. With this commit the ptype is correctly set to GEN6_VC1_BI_PICTURE for advanced profiles.

Maybe this is also needed for the other platforms affected by commit 1591f6c1be689c5265cb5beab18c97771d056cb9  but I have no hardware to test it.