### PR TITLE
Fix QualityRange query for the VP8 encoder

### DIFF
--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -1147,6 +1147,8 @@ i965_GetConfigAttributes(VADriverContextP ctx,
                 else if (profile == VAProfileVP9Profile0 &&
                          entrypoint == VAEntrypointEncSliceLP) {
                     attrib_list[i].value = ENCODER_QUALITY_RANGE_VP9;
+                } else if (profile == VAProfileVP8Version0_3) {
+                    attrib_list[i].value = ENCODER_QUALITY_RANGE;
                 }
 
                 break;


### PR DESCRIPTION
The VP8 encoder supports two quality levels, one for
the normal mode and the other for performance-mode(less-quality).
This patch ensures that the ConfigAttrib query advertising
the correct range.