### PR TITLE
build: Allow clean build on OpenBSD 6.6.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,17 @@ if version_arr.length() == 4
 endif
 
 cc = meson.get_compiler('c')
-dl_dep = cc.find_library('dl')
+
+dl_check_code = '''
+#include <dlfcn.h>
+void func() { dlerror(); }
+'''
+dl_system_provided = cc.compiles(dl_check_code, name : 'dl system provided?')
+
+if not dl_system_provided
+  dl_dep = cc.find_library('dl')
+endif
+
 mathlib_dep = cc.find_library('m', required : false)
 
 git = find_program('git', required : false)

--- a/src/i965_encoder_utils.c
+++ b/src/i965_encoder_utils.c
@@ -82,6 +82,7 @@ struct __avc_bitstream {
 
 typedef struct __avc_bitstream avc_bitstream;
 
+#ifndef __BSD_VISIBLE
 static unsigned int
 swap32(unsigned int val)
 {
@@ -92,6 +93,7 @@ swap32(unsigned int val)
             (pval[2] << 8)      |
             (pval[3] << 0));
 }
+#endif
 
 static void
 avc_bitstream_start(avc_bitstream *bs)

--- a/src/meson.build
+++ b/src/meson.build
@@ -214,14 +214,18 @@ if thread_dep.found()
   cflags += [ '-DPTHREADS' ]
 endif
 
+
 shared_deps = [
-  dl_dep,
   mathlib_dep,
   thread_dep,
   libdrm_dep,
   libdrm_intel_dep,
   libva_dep,
 ]
+
+if not dl_system_provided
+  shared_deps += [ dl_dep ]
+endif
 
 if WITH_X11
   shared_deps += [ libva_x11_dep ]


### PR DESCRIPTION
We don't need to link with -ldl on OpenBSD.
Add new check to see if we need to find a libdl
before we assume we do.

swap32 is provided by OpenBSD.  Use it when
available.