### PR TITLE
gen9_vp9_encoder: Relax the compressed frames minimum size restriction.

### DIFF
--- a/src/gen9_vp9_encoder.c
+++ b/src/gen9_vp9_encoder.c
@@ -1593,7 +1593,10 @@ intel_vp9enc_construct_picstate_batchbuf(VADriverContextP ctx,
         *cmd_ptr++ = 0;
 
         /* dw31 */
-        *cmd_ptr++ = (0 << 30) | 1;
+        /* dw31 is for restricting the compressed frames minimum size
+         * and we don't impose any. */
+        *cmd_ptr++ = 0;
+
         /* dw32 */
         *cmd_ptr++ = vp9_state->frame_header.bit_offset_first_partition_size;
 


### PR DESCRIPTION
The current implementation of the CQP mode encode has a
compressed buffer size restriction of 4Kb. The restriction
doesn't make sense for low-resolution & low-bitrate
video encoding use cases since inter-frames can be encoded
with much less number of bytes.

For eg: most of the P-frames in a video-conferencing session
of 640x480 resolution at 750kbps require only 1Kb bitrate
allocation and currently the hardware PAK unit fill the rest
of the 3Kb (4Kb-1Kb) with zeros. This will jeopardize the
quality & bit-rate allocation of the hybrid CBR encode
models[1] where we run the bitrate control algorithm in
software clubbed with a CQP hardware encoder:
[1]: https://cgit.freedesktop.org/~sree/gstreamer-vaapi/commit/?h=VP9_SVC_and_SoftwareBRC&id=355f16bdb32965425b274aa082c1334b0edd5992).