### PR TITLE
fix exporting buffers with 3 planes and VA_EXPORT_SURFACE_SEPARATE_LAYERS

### DIFF
--- a/src/i965_drv_video.c
+++ b/src/i965_drv_video.c
@@ -6904,16 +6904,17 @@ i965_ExportSurfaceHandle(VADriverContextP ctx, VASurfaceID surface_id,
                 else
                   y_offset = obj_surface->y_cr_offset;
             } else {
-                y_offset = obj_surface->y_cr_offset - obj_surface->y_cb_offset;              
-                if (y_offset < 0)
-                  y_offset = -y_offset;
+                if (obj_surface->y_cb_offset < obj_surface->y_cr_offset)
+                  y_offset = obj_surface->y_cr_offset;
+                else
+                  y_offset = obj_surface->y_cb_offset;
                 pitch  = obj_surface->cb_cr_pitch;
                 height = obj_surface->cb_cr_height;
             }
 
             desc->layers[p].offset[0] = offset;
             desc->layers[p].pitch[0]  = pitch;
-            offset += pitch * y_offset;
+            offset = obj_surface->width * y_offset;
         }
     }
 


### PR DESCRIPTION
To get the plane offset, y_cb_offset or y_cr_offset must be multiplied with
the pitch for the 'Y' plane. See for example i965_DeriveImage().

Without this, exporting formats with 3 planes where cb_cr_pitch == width/2
is broken, because the offset of the third plane is calculated incorrectly.