### PR TITLE
Fix JPEG decoding of an oddly encoded files on gen7/8

### DIFF
--- a/src/gen75_mfd.c
+++ b/src/gen75_mfd.c
@@ -2844,7 +2844,7 @@ gen75_mfd_jpeg_qm_state(VADriverContextP ctx,
     assert(pic_param->num_components <= 3);
 
     for (index = 0; index < pic_param->num_components; index++) {
-        int id = pic_param->components[index].component_id - pic_param->components[0].component_id + 1;
+        unsigned char id = pic_param->components[index].component_id - pic_param->components[0].component_id + 1;
         int qm_type;
         unsigned char *qm = iq_matrix->quantiser_table[pic_param->components[index].quantiser_table_selector];
         unsigned char raster_qm[64];
@@ -2875,6 +2875,7 @@ gen75_mfd_jpeg_bsd_object(VADriverContextP ctx,
 {
     struct intel_batchbuffer *batch = gen7_mfd_context->base.batch;
     int scan_component_mask = 0;
+    unsigned char id;
     int i;
 
     assert(slice_param->num_components > 0);
@@ -2882,7 +2883,8 @@ gen75_mfd_jpeg_bsd_object(VADriverContextP ctx,
     assert(slice_param->num_components <= pic_param->num_components);
 
     for (i = 0; i < slice_param->num_components; i++) {
-        switch (slice_param->components[i].component_selector - pic_param->components[0].component_id + 1) {
+        id = slice_param->components[i].component_selector - pic_param->components[0].component_id + 1;
+        switch (id) {
         case 1:
             scan_component_mask |= (1 << 0);
             break;

--- a/src/gen7_mfd.c
+++ b/src/gen7_mfd.c
@@ -2497,7 +2497,7 @@ gen7_mfd_jpeg_qm_state(VADriverContextP ctx,
     assert(pic_param->num_components <= 3);
 
     for (index = 0; index < pic_param->num_components; index++) {
-        int id = pic_param->components[index].component_id - pic_param->components[0].component_id + 1;
+        unsigned char id = pic_param->components[index].component_id - pic_param->components[0].component_id + 1;
         int qm_type;
         unsigned char *qm = iq_matrix->quantiser_table[pic_param->components[index].quantiser_table_selector];
         unsigned char raster_qm[64];
@@ -2528,6 +2528,7 @@ gen7_mfd_jpeg_bsd_object(VADriverContextP ctx,
 {
     struct intel_batchbuffer *batch = gen7_mfd_context->base.batch;
     int scan_component_mask = 0;
+    unsigned char id;
     int i;
 
     assert(slice_param->num_components > 0);
@@ -2535,7 +2536,8 @@ gen7_mfd_jpeg_bsd_object(VADriverContextP ctx,
     assert(slice_param->num_components <= pic_param->num_components);
 
     for (i = 0; i < slice_param->num_components; i++) {
-        switch (slice_param->components[i].component_selector - pic_param->components[0].component_id + 1) {
+        id = slice_param->components[i].component_selector - pic_param->components[0].component_id + 1;
+        switch (id) {
         case 1:
             scan_component_mask |= (1 << 0);
             break;

--- a/src/gen8_mfd.c
+++ b/src/gen8_mfd.c
@@ -2550,7 +2550,7 @@ gen8_mfd_jpeg_qm_state(VADriverContextP ctx,
     assert(pic_param->num_components <= 3);
 
     for (index = 0; index < pic_param->num_components; index++) {
-        int id = pic_param->components[index].component_id - pic_param->components[0].component_id + 1;
+        unsigned char id = pic_param->components[index].component_id - pic_param->components[0].component_id + 1;
         int qm_type;
         unsigned char *qm = iq_matrix->quantiser_table[pic_param->components[index].quantiser_table_selector];
         unsigned char raster_qm[64];
@@ -2581,6 +2581,7 @@ gen8_mfd_jpeg_bsd_object(VADriverContextP ctx,
 {
     struct intel_batchbuffer *batch = gen7_mfd_context->base.batch;
     int scan_component_mask = 0;
+    unsigned char id;
     int i;
 
     assert(slice_param->num_components > 0);
@@ -2588,7 +2589,8 @@ gen8_mfd_jpeg_bsd_object(VADriverContextP ctx,
     assert(slice_param->num_components <= pic_param->num_components);
 
     for (i = 0; i < slice_param->num_components; i++) {
-        switch (slice_param->components[i].component_selector - pic_param->components[0].component_id + 1) {
+        id = slice_param->components[i].component_selector - pic_param->components[0].component_id + 1;
+        switch (id) {
         case 1:
             scan_component_mask |= (1 << 0);
             break;


### PR DESCRIPTION
Intel VA-API driver fails to decode couple JPEG files for me because of the offending implicit u8->int32 expansion in the code of the driver.  This PR fixes the implicit integer expansion and decoding works properly now.