### PR TITLE
Update COPYING with copyright line

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,3 +1,5 @@
+    Copyright (c) 2023 Intel Corporation
+
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the
     "Software"), to deal in the Software without restriction, including


### PR DESCRIPTION
The MIT license requires a copyright line specifying the year of application and copyright holder. [0]

Add this line to the existing COPYING file containing the rest of the license text.

[0] https://opensource.org/license/mit/